### PR TITLE
Display active surveys

### DIFF
--- a/surveys/admin.py
+++ b/surveys/admin.py
@@ -31,7 +31,7 @@ class SurveyAdmin(NestedModelAdmin):
     model = Survey
     inlines = [QuestionInline]
     readonly_fields = ['creation_date']
-    list_display = ['name', 'creator', 'creation_date', 'pub_date']
+    list_display = ['name', 'creator', 'creation_date', 'pub_date', 'active']
 
 
 class ResearcherAdmin(UserAdmin):

--- a/surveys/admin.py
+++ b/surveys/admin.py
@@ -31,7 +31,7 @@ class SurveyAdmin(NestedModelAdmin):
     model = Survey
     inlines = [QuestionInline]
     readonly_fields = ['creation_date']
-    list_display = ['name', 'creator', 'creation_date', 'pub_date', 'active']
+    list_display = ['name', 'creator', 'creation_date', 'description','active']
 
 
 class ResearcherAdmin(UserAdmin):

--- a/surveys/models.py
+++ b/surveys/models.py
@@ -23,8 +23,10 @@ class Survey(models.Model):
     name = models.CharField(max_length=300)
     creation_date = models.DateTimeField(default=timezone.now, editable=False)
     pub_date = models.DateTimeField('date published')
+    active = models.BooleanField()
 
-    def __str__(self): return self.name
+    def __str__(self):
+        return self.name
 
     class Meta:
         verbose_name = "Survey"

--- a/surveys/models.py
+++ b/surveys/models.py
@@ -22,7 +22,7 @@ class Survey(models.Model):
     creator = models.ForeignKey(Researcher, on_delete=models.CASCADE, default=0)
     name = models.CharField(max_length=300)
     creation_date = models.DateTimeField(default=timezone.now, editable=False)
-    pub_date = models.DateTimeField('date published')
+    description = models.CharField(max_length=100000)
     active = models.BooleanField()
 
     def __str__(self):

--- a/surveys/static/surveys/js/scripts.js
+++ b/surveys/static/surveys/js/scripts.js
@@ -2,3 +2,7 @@
 $(document).ready(function () {
     feather.replace();
 });
+
+function redirect() {
+    alert("what did you expect lmao")
+}

--- a/surveys/templates/base.html
+++ b/surveys/templates/base.html
@@ -96,7 +96,7 @@
                                 <h6 class="px-3 pt-3">Surveys</h6>
                                 <ul class="nav flex-column flex-nowrap text-truncate">
                                     <li class="nav-item">
-                                        <a class="nav-link active" href="#">Active</a>
+                                        <a class="nav-link active" href="{% url 'surveys:active' %}">Active</a>
                                     </li>
                                     <li class="nav-item">
                                         <a class="nav-link" href="#">Link</a>
@@ -132,11 +132,11 @@
                         <div class="row">
                             <div class="col-xs-12 col-sm-12 col-md-12 mt-2 mt-sm-5">
                                 <ul class="list-unstyled list-inline social text-center">
-                                    <li class="list-inline-item"><a href="javascript:void();"><i class="fa fa-facebook"></i></a></li>
-                                    <li class="list-inline-item"><a href="javascript:void();"><i class="fa fa-twitter"></i></a></li>
-                                    <li class="list-inline-item"><a href="javascript:void();"><i class="fa fa-instagram"></i></a></li>
-                                    <li class="list-inline-item"><a href="javascript:void();"><i class="fa fa-google-plus"></i></a></li>
-                                    <li class="list-inline-item"><a href="javascript:void();" target="_blank"><i class="fa fa-envelope"></i></a></li>
+                                    <li class="list-inline-item"><a href="javascript:redirect();"><i class="fa fa-facebook"></i></a></li>
+                                    <li class="list-inline-item"><a href="javascript:redirect();"><i class="fa fa-twitter"></i></a></li>
+                                    <li class="list-inline-item"><a href="javascript:redirect();"><i class="fa fa-instagram"></i></a></li>
+                                    <li class="list-inline-item"><a href="javascript:redirect();"><i class="fa fa-google-plus"></i></a></li>
+                                    <li class="list-inline-item"><a href="javascript:redirect();" target="_blank"><i class="fa fa-envelope"></i></a></li>
                                 </ul>
                             </div>
                         </div>

--- a/surveys/templates/base.html
+++ b/surveys/templates/base.html
@@ -96,13 +96,7 @@
                                 <h6 class="px-3 pt-3">Surveys</h6>
                                 <ul class="nav flex-column flex-nowrap text-truncate">
                                     <li class="nav-item">
-                                        <a class="nav-link active" href="{% url 'surveys:active' %}">Active</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" href="#">Link</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" href="#">Link</a>
+                                        <a class="nav-link active" href="{% url 'surveys:active' %}">Active surveys</a>
                                     </li>
                                 </ul>
                             </div>

--- a/surveys/templates/errors/403.html
+++ b/surveys/templates/errors/403.html
@@ -3,5 +3,5 @@
 {% block title %}Access Denied!{% endblock %}
 
 {% block content %}
-<p>You tried to access a forbidden page. Please log in or request access to the resource</p>
+<p>{{message}}</p>
 {% endblock %}

--- a/surveys/templates/surveys/active.html
+++ b/surveys/templates/surveys/active.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+<!-- include crispy -->
+{% load crispy_forms_tags %}
+
+{% block title %}Index{% endblock %}
+
+{% block content %}
+    {% if user.is_superuser %}
+<p>You're logged in under superuser privileges. All <strong>active</strong> surveys are shown.</p>
+    {% elif user.is_authenticated %}
+        <p>Your <strong>active</strong> surveys:</p>
+    {% endif %}
+    {% for survey in active_surveys %}
+    <a href=../{{survey.id}}>{{survey.name}}</a>
+    {% endfor %}
+{% endblock %}
+extra soi hello

--- a/surveys/templates/surveys/detail.html
+++ b/surveys/templates/surveys/detail.html
@@ -12,6 +12,7 @@
         <p>You are the creator of this survey</p>
     {% endif %}
     <h1>{{survey.name}}</h1>
+    <p>{{survey.description}}</p>
     {% for question in survey.question_set.all %} <!-- yeah this is how you go up the foreign key -->
         {{ question.question_text }}
     {% endfor %}

--- a/surveys/templates/surveys/detail.html
+++ b/surveys/templates/surveys/detail.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+<!-- include crispy -->
+{% load crispy_forms_tags %}
+
+{% block title %}Index{% endblock %}
+
+{% block content %}
+    {% if user.is_superuser %}
+        <p>You're logged in under superuser privileges. All surveys are shown.</p>
+    {% elif user == survey.creator %}
+        <p>You are the creator of this survey</p>
+    {% endif %}
+    <h1>{{survey.name}}</h1>
+{% endblock %}
+extra soi hello

--- a/surveys/templates/surveys/detail.html
+++ b/surveys/templates/surveys/detail.html
@@ -12,5 +12,8 @@
         <p>You are the creator of this survey</p>
     {% endif %}
     <h1>{{survey.name}}</h1>
+    {% for question in survey.question_set.all %} <!-- yeah this is how you go up the foreign key -->
+        {{ question.question_text }}
+    {% endfor %}
 {% endblock %}
 extra soi hello

--- a/surveys/templates/surveys/results.html
+++ b/surveys/templates/surveys/results.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/surveys/urls.py
+++ b/surveys/urls.py
@@ -8,5 +8,7 @@ app_name = 'surveys'
 urlpatterns = [
     path('', views.index, name='index'),
     path('<int:survey_id>/results/', views.results, name="results"),
-    path('create/', views.CreateSurvey.as_view(), name='create')
+    path('<int:survey_id>/', views.detail, name="detail"),
+    path('create/', views.CreateSurvey.as_view(), name='create'),
+    path('active/', views.active, name='active')
 ]

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -34,8 +34,8 @@ def detail(request, survey_id):
     template = 'surveys/detail.html'
     survey = Survey.objects.filter(pk=survey_id)[0]
     if survey.creator != request.user and not request.user.is_superuser:
-        raise PermissionDenied("You don't have access to this survey, please contact " + survey.creator.username)
-            # TODO: make this researcher's email. We need to modify models to achieve this.
+        raise PermissionDenied("You have tried to access " + survey.name + ". To gain permissions please contact "
+                               + survey.creator.email + ".")
     context = {'survey': survey}
     return render(request, template, context)
 
@@ -55,15 +55,10 @@ def active(request):
 """ Errors """
 
 
-def permission_denied(request):
-    return render(request, 'errors/403.html')
-
-
 def handler403(request, exception):
     response = render_to_response("errors/403.html")
-    response.status_code = 403
     context = {'message': exception.args[0]}  # this is the error message called with the exception
-    return render(request, 'errors/403.html', context)
+    return render(request, 'errors/403.html', context, status=403)
 
 
 class SignUp(CreateView):

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -22,17 +22,48 @@ def index(request):
 
 
 def results(survey_id):
-    response = "You're looking at the results of survey %s."
-    return HttpResponse(response % survey_id)
+    template = 'surveys/results.html'
+    survey = Survey.objects.get(pk=survey_id)
+    context = {'survey': survey}
+    return render(survey_id, template, context)
+
+
+def detail(request, survey_id):
+    if not request.user.is_authenticated:  # user is not logged in
+        raise PermissionDenied("User is not logged in")
+    template = 'surveys/detail.html'
+    survey = Survey.objects.filter(pk=survey_id)[0]
+    if survey.creator != request.user and not request.user.is_superuser:
+        raise PermissionDenied("You don't have access to this survey, please contact " + survey.creator.username)
+            # TODO: make this researcher's email. We need to modify models to achieve this.
+    context = {'survey': survey}
+    return render(request, template, context)
+
+
+def active(request):
+    template = 'surveys/active.html'
+    if not request.user.is_authenticated:  # user is not logged in
+        raise PermissionDenied("User is not logged in.")
+    if request.user.is_superuser:
+        active_surveys = Survey.objects.filter(active=True)
+    elif request.user.is_authenticated:
+        active_surveys = Survey.objects.filter(creator=request.user, active=True)
+    context = {'active_surveys': active_surveys}
+    return render(request, template, context)
 
 
 """ Errors """
 
 
-def handler403():
+def permission_denied(request):
+    return render(request, 'errors/403.html')
+
+
+def handler403(request, exception):
     response = render_to_response("errors/403.html")
     response.status_code = 403
-    return response
+    context = {'message': exception.args[0]}  # this is the error message called with the exception
+    return render(request, 'errors/403.html', context)
 
 
 class SignUp(CreateView):
@@ -65,7 +96,7 @@ class CreateSurvey(CreateView):
         form = self.get_form(form_class)
         question_form = QuestionFormSet(self.request.POST)
         choice_form = ChoiceFormSet(self.request.POST)
-        if (form.is_valid() and question_form.is_valid() and choice_form.is_valid()):
+        if form.is_valid() and question_form.is_valid() and choice_form.is_valid():
             return self.form_valid(form, question_form, choice_form)
         else:
             return self.form_invalid(form, question_form, choice_form)


### PR DESCRIPTION
Removed "pub_date" and changed it for Boolean "active". Then I created "/active" where the user can view surveys they have access to, and are redirected unless they are logged in or aren't the survey's creators/admins. Additionally, there is now a detailed view of survey which can be accessed on "/surveys/<survey_id>". 

I suggest we put a giant "START SURVEY FAM" button there.